### PR TITLE
Add macOS install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Morrigan temporary files and folders
 morrigan-env.sh
 logs/
 deps/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "sst-core"]
 	path = sst-core
-	url = git@github.com:hpcgarage/sst-core.git
+	url = https://github.com/hpcgarage/sst-core.git
 [submodule "sst-elements"]
 	path = sst-elements
-	url = git@github.com:hpcgarage/sst-elements.git
+	url = https://github.com/hpcgarage/sst-elements.git
 [submodule "DRAMsim3"]
 	path = DRAMsim3
-	url = git@github.com:hpcgarage/DRAMsim3.git
+	url = https://github.com/hpcgarage/DRAMsim3.git

--- a/README.md
+++ b/README.md
@@ -3,16 +3,28 @@
 The Morrígan project is aimed at adding phase detection and model swapping capabilities to the [Structural Simulation Toolkit](https://sst-simulator.org/). 
 
 ## Installation
-First install Python 3, then follow these instructions.
+First install Python 3, then follow these instructions for Linux and macOS. 
 
 ```
 git clone git@github.com:hpcgarage/morrigan.git
 cd morrigan
 git submodule update --init --recursive
+```
+
+For Linux do the following steps.
+```
 ./install-dependencies.sh
 ./configure-morrigan.sh
 ./build-and-install-morrigan.sh
 source morrigan-env.sh
+```
+
+For macOS do the following steps.
+```
+./install-dependencies-macos.sh
+source morrigan-env.sh
+./configure-morrigan-macos.sh
+./build-and-install-morrigan.sh
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ For macOS do the following steps.
 ```
 ./install-dependencies-macos.sh
 source morrigan-env.sh
-./configure-morrigan-macos.sh
-./build-and-install-morrigan.sh
+./install-morrigan-macos.sh
 ```
 
 ## Troubleshooting

--- a/configure-morrigan-macos.sh
+++ b/configure-morrigan-macos.sh
@@ -1,0 +1,86 @@
+set -euo pipefail
+MORRIGAN_ENV_FILE=morrigan-env.sh
+. $MORRIGAN_ENV_FILE
+
+MORRIGAN_DEBUG=""
+
+if [ -z ${MORRIGAN_HOME+x} ];
+then
+    echo "ERROR: MORRIGAN_HOME is unset";
+    exit
+fi
+
+LOGFILE=$MORRIGAN_LOGS/configure-morrigan.out
+mkdir -p $MORRIGAN_LOGS
+rm -f $LOGFILE
+touch $LOGFILE
+
+SST_CORE_HOME=$MORRIGAN_HOME/install
+
+####################
+# Install SST Core #
+####################
+
+cd sst-core
+./autogen.sh
+mkdir -p build
+cd build
+../configure CPPFLAGS="-fno-omit-frame-pointer" $MORRIGAN_DEBUG --prefix=$SST_CORE_HOME --disable-mpi
+make all -j8
+make install
+
+cd $MORRIGAN_HOME
+
+echo "export SST_CORE_HOME=$SST_CORE_HOME" >> $MORRIGAN_ENV_FILE
+
+echo
+echo "MORRIGAN: sst-core has been configured." | tee -a $LOGFILE
+echo
+wait
+
+####################
+# Install DRAMsim3 #
+####################
+
+cd DRAMsim3
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+make -j8
+MORRIGAN_DRAMDIR=$PWD
+cd $MORRIGAN_HOME
+
+echo "export MORRIGAN_DRAMDIR=$MORRIGAN_DRAMDIR" >> $MORRIGAN_ENV_FILE
+
+echo
+echo "MORRIGAN: DRAMsim3 has been configured." | tee -a $LOGFILE
+echo
+wait
+
+########################
+# Install SST Elements #
+########################
+
+#TODO: Check the output of elements config to make sure it built ariel and detected dramsim3
+SST_ELEMENTS_HOME=$MORRIGAN_HOME/install
+SST_ELEMENTS_ROOT="sst-elements"
+
+echo export SST_ELEMENTS_HOME=$SST_ELEMENTS_HOME >> $MORRIGAN_ENV_FILE
+echo export SST_ELEMENTS_ROOT=$SST_ELEMENTS_ROOT >> $MORRIGAN_ENV_FILE
+
+cd sst-elements
+# Remove Werror
+find . -name Makefile.am -exec sed -i "" -e  s'/-Werror//g' {} \;
+./autogen.sh
+# Don't build elements listed in disabled-elements.txt
+while read p;
+do
+    sed -i "" -e "/ac_config_files.*$p/s/^/#/" configure
+    sed -i "" -e "/active_element_libraries.*$p/s/^/#/" configure
+done < $MORRIGAN_HOME/disabled-elements.txt
+
+./configure CPPFLAGS="-fno-omit-frame-pointer" $MORRIGAN_DEBUG --prefix=$SST_ELEMENTS_HOME --with-sst-core=$SST_CORE_HOME --with-pin=$MORRIGAN_PIN_HOME --with-dramsim3=$MORRIGAN_DRAMDIR
+#make all -j8
+#make install
+
+cd $MORRIGAN_HOME
+
+echo "Done"

--- a/install-dependencies-macos.sh
+++ b/install-dependencies-macos.sh
@@ -1,4 +1,4 @@
-# File: install-dependencies.sh
+# File: install-dependencies-macos.sh
 
 # This file downloads and installs dependencies of the Morrigan project.
 # It is designed to be run from the top directory of the project.
@@ -28,7 +28,7 @@ AUTOCONF_VERSION=2.69
 AUTOMAKE_VERSION=1.16.2
 LIBTOOL_VERSION=2.4.6
 
-CMAKEURL='https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-macos-universal.tar.gz'
+CMAKEURL='https://github.com/Kitware/CMake/releases/download/v3.21.4/cmake-3.21.4-macos-universal.tar.gz'
 PINURL='https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.20-98437-gf02b61307-clang-mac.tar.gz'
 
 
@@ -82,6 +82,8 @@ mkdir -p deps/cmake
 mkdir -p $PREFIX/bin
 mkdir -p $PREFIX/share
 
+echo "MORRIGAN: Downloading Cmake." | tee -a $LOGFILE
+
 cd deps/cmake
 curl -L $CMAKEURL > cmake.tar.gz
 tar xzf *.tar.gz
@@ -95,10 +97,15 @@ echo "MORRIGAN: Cmake successfully installed." | tee -a $LOGFILE
 echo
 sleep 1
 
-# Install Pin3
+################
+# Install Pin3 #
+################
+
+echo "MORRIGAN: Downloading Pin 3." | tee -a $LOGFILE
+
 mkdir -p $MORRIGAN_HOME/install/packages/pin
 cd $MORRIGAN_HOME/install/packages/pin
-curl -L $PINURL > pin3.tar.gz
+curl -L $PINURL > pin-3.tar.gz
 tar xvzf *.tar.gz
 MORRIGAN_PIN_HOME=$PWD/$(ls -d */)
 
@@ -112,4 +119,3 @@ echo "MORRIGAN: Pin 3 successfully installed." >> $LOGFILE
 echo
 echo "MORRIGAN: Autotools, Cmake, and Pin3 have been installed."
 echo "MORRIGAN: Update your path by running \"source $MORRIGAN_ENV_FILE\"" | tee -a $LOGFILE
-

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -28,8 +28,8 @@ AUTOCONF_VERSION=2.69
 AUTOMAKE_VERSION=1.16.2
 LIBTOOL_VERSION=2.4.6
 
-CMAKEURL='https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-macos-universal.tar.gz'
-PINURL='https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.20-98437-gf02b61307-clang-mac.tar.gz'
+CMAKEURL='https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-x86_64.tar.gz'
+PINURL='https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.20-98437-gf02b61307-gcc-linux.tar.gz'
 
 
 #########################################################
@@ -46,10 +46,10 @@ mkdir -p $MORRIGAN_HOME/install
 
 cd deps
 
-curl -L http://ftp.gnu.org/gnu/m4/m4-${M4_VERSION}.tar.gz > m4-${M4_VERSION}.tar.gz
-curl -L http://ftp.gnu.org/gnu/autoconf/autoconf-${AUTOCONF_VERSION}.tar.gz > autoconf-${AUTOCONF_VERSION}.tar.gz
-curl -L http://ftp.gnu.org/gnu/automake/automake-${AUTOMAKE_VERSION}.tar.gz > automake-${AUTOMAKE_VERSION}.tar.gz
-curl -L http://ftp.gnu.org/gnu/libtool/libtool-${LIBTOOL_VERSION}.tar.gz > libtool-${LIBTOOL_VERSION}.tar.gz
+wget http://ftp.gnu.org/gnu/m4/m4-${M4_VERSION}.tar.gz
+wget http://ftp.gnu.org/gnu/autoconf/autoconf-${AUTOCONF_VERSION}.tar.gz
+wget http://ftp.gnu.org/gnu/automake/automake-${AUTOMAKE_VERSION}.tar.gz
+wget http://ftp.gnu.org/gnu/libtool/libtool-${LIBTOOL_VERSION}.tar.gz
 
 # Decompress
 gzip -dc m4-${M4_VERSION}.tar.gz | tar xvf -

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -83,11 +83,11 @@ mkdir -p $PREFIX/bin
 mkdir -p $PREFIX/share
 
 cd deps/cmake
-curl -L $CMAKEURL > cmake.tar.gz
+wget $CMAKEURL
 tar xzf *.tar.gz
 cd $(ls -d */)
-# cp bin/* $PREFIX/bin/
-# cp -r share/* $PREFIX/share/
+cp bin/* $PREFIX/bin/
+cp -r share/* $PREFIX/share/
 
 cd $MORRIGAN_HOME
 echo
@@ -98,7 +98,7 @@ sleep 1
 # Install Pin3
 mkdir -p $MORRIGAN_HOME/install/packages/pin
 cd $MORRIGAN_HOME/install/packages/pin
-curl -L $PINURL > pin3.tar.gz
+wget $PINURL
 tar xvzf *.tar.gz
 MORRIGAN_PIN_HOME=$PWD/$(ls -d */)
 

--- a/install-morrigan-macos.sh
+++ b/install-morrigan-macos.sh
@@ -78,8 +78,8 @@ do
 done < $MORRIGAN_HOME/disabled-elements.txt
 
 ./configure CPPFLAGS="-fno-omit-frame-pointer" $MORRIGAN_DEBUG --prefix=$SST_ELEMENTS_HOME --with-sst-core=$SST_CORE_HOME --with-pin=$MORRIGAN_PIN_HOME --with-dramsim3=$MORRIGAN_DRAMDIR
-#make all -j8
-#make install
+make all -j8
+make install
 
 cd $MORRIGAN_HOME
 


### PR DESCRIPTION
Adds build script for macOS. Changes the repo URL links in the `.gitmodules` to remove need for working SSH access to Github. Updates `README` to reflect build instructions for Linux and macOS.

Tested on macOS 12.1