### PR TITLE
Add Docker support 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:20.04
+
+RUN  apt-get update \
+  && apt-get install -y wget \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR ../morrigan
+ENTRYPOINT ./install-morrigan-linux.sh

--- a/install-morrigan-linux.sh
+++ b/install-morrigan-linux.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+./install-dependencies.sh
+./configure-morrigan.sh
+./build-and-install-morrigan.sh
+source morrigan-env.sh

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,0 +1,4 @@
+ROOT_DIR="$(pwd)"
+
+docker build -t morrigan-docker .
+docker run --rm -it --name="morrigan" -v "${ROOT_DIR}/":/morrigan -w="/morrigan" morrigan-docker


### PR DESCRIPTION
Uses the Ubuntu docker image to run Morrigan to create a user-agnostic environment for build testing and using Morrigan.

- [ ] Testing new build scripts in #10
- [ ] Add build testing using Github Actions